### PR TITLE
Add path option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,7 @@ const cli = meow(`
 
 	Options
 	  --use-get  Use the HTTP-method GET instead of HEAD to test if the server is ready
+	  --path  Use a custom path. For example, /health for a health-check endpoint.
 
 	Example
 	  $ wait-for-localhost 8080 && echo 'Server is ready'
@@ -21,6 +22,10 @@ const cli = meow(`
 	flags: {
 		useGet: {
 			type: 'boolean',
+		},
+		path: {
+			type: 'string',
+			default: '/',
 		},
 	},
 });

--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,7 @@ const cli = meow(`
 
 	Options
 	  --use-get  Use the HTTP-method GET instead of HEAD to test if the server is ready
-	  --path  Use a custom path. For example, /health for a health-check endpoint.
+	  --path     Use a custom path. For example, /health for a health-check endpoint.
 
 	Example
 	  $ wait-for-localhost 8080 && echo 'Server is ready'

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ $ wait-for-localhost --help
 
   Options
     --use-get  Use the HTTP-method GET instead of HEAD to test if the server is ready
-	  --path  Use a custom path. For example, /health for a health-check endpoint.
+    --path     Use a custom path. For example, /health for a health-check endpoint.
 
   Example
     $ wait-for-localhost 8080 && echo 'Server is ready'

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ $ wait-for-localhost --help
 
   Options
     --use-get  Use the HTTP-method GET instead of HEAD to test if the server is ready
+	  --path  Use a custom path. For example, /health for a health-check endpoint.
 
   Example
     $ wait-for-localhost 8080 && echo 'Server is ready'

--- a/test.js
+++ b/test.js
@@ -36,3 +36,20 @@ test('use get method', async t => {
 
 	await server.close();
 });
+
+test('use path option', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/health', async (request, response) => {
+		await delay(1000);
+		response.end();
+		t.pass();
+	});
+
+	await execa('./cli.js', [server.port, '--path', '/health']);
+
+	t.pass();
+
+	await server.close();
+});


### PR DESCRIPTION
This adds to the CLI the `path` option that it's already available on `wait-for-localhost`. I copied the description from that repository. Hopefully this is fine!