### PR TITLE
Support different HTTP status codes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ const cli = meow(`
 	  $ wait-for-localhost [port]
 
 	Options
-	  --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready
+	  --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready.
 	  --path          Use a custom path. For example, /health for a health-check endpoint.
 	  --status-codes  Define status codes indicating the server is ready. [Default: 200]
 

--- a/cli.js
+++ b/cli.js
@@ -39,7 +39,8 @@ const cli = meow(`
 const [port] = cli.input;
 
 (async () => {
-	cli.flags.statusCodes = cli.flags.statusCodes.split(',').map(it => Number.parseInt(it, 10));
+	cli.flags.statusCodes = cli.flags.statusCodes.split(',').map(statusCode => Number.parseInt(statusCode, 10));
+
 	try {
 		await waitForLocalhost({
 			port,

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ const cli = meow(`
 	Options
 	  --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready
 	  --path          Use a custom path. For example, /health for a health-check endpoint.
-	  --status-codes  Define status codes indicating the server is ready. 
+	  --status-codes  Define status codes indicating the server is ready. [Default: 200]
 
 	Examples
 	  $ wait-for-localhost 8080 && echo 'Server is ready'

--- a/cli.js
+++ b/cli.js
@@ -12,8 +12,9 @@ const cli = meow(`
 	  --path          Use a custom path. For example, /health for a health-check endpoint.
 	  --status-codes  Define status codes indicating the server is ready. 
 
-	Example
+	Examples
 	  $ wait-for-localhost 8080 && echo 'Server is ready'
+	  $ wait-for-localhost 8080 --status-codes 200,201 && echo 'Server is ready'
 `, {
 	importMeta: import.meta,
 	input: {
@@ -29,9 +30,8 @@ const cli = meow(`
 			default: '/',
 		},
 		statusCodes: {
-			type: 'number',
-			default: [200],
-			isMultiple: true,
+			type: 'string',
+			default: '200',
 		},
 	},
 });
@@ -39,6 +39,7 @@ const cli = meow(`
 const [port] = cli.input;
 
 (async () => {
+	cli.flags.statusCodes = cli.flags.statusCodes.split(',').map(it => Number.parseInt(it, 10));
 	try {
 		await waitForLocalhost({
 			port,

--- a/cli.js
+++ b/cli.js
@@ -8,8 +8,9 @@ const cli = meow(`
 	  $ wait-for-localhost [port]
 
 	Options
-	  --use-get  Use the HTTP-method GET instead of HEAD to test if the server is ready
-	  --path     Use a custom path. For example, /health for a health-check endpoint.
+	  --use-get     Use the HTTP-method GET instead of HEAD to test if the server is ready
+	  --path        Use a custom path. For example, /health for a health-check endpoint.
+	  --statusCode  Define status codes indicating the server is ready. 
 
 	Example
 	  $ wait-for-localhost 8080 && echo 'Server is ready'
@@ -26,6 +27,11 @@ const cli = meow(`
 		path: {
 			type: 'string',
 			default: '/',
+		},
+		statusCode: {
+			type: 'number',
+			default: [200],
+			isMultiple: true,
 		},
 	},
 });

--- a/cli.js
+++ b/cli.js
@@ -8,9 +8,9 @@ const cli = meow(`
 	  $ wait-for-localhost [port]
 
 	Options
-	  --use-get     Use the HTTP-method GET instead of HEAD to test if the server is ready
-	  --path        Use a custom path. For example, /health for a health-check endpoint.
-	  --statusCode  Define status codes indicating the server is ready. 
+	  --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready
+	  --path          Use a custom path. For example, /health for a health-check endpoint.
+	  --status-codes  Define status codes indicating the server is ready. 
 
 	Example
 	  $ wait-for-localhost 8080 && echo 'Server is ready'
@@ -28,7 +28,7 @@ const cli = meow(`
 			type: 'string',
 			default: '/',
 		},
-		statusCode: {
+		statusCodes: {
 			type: 'number',
 			default: [200],
 			isMultiple: true,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	],
 	"dependencies": {
 		"meow": "^10.1.1",
-		"wait-for-localhost": "^4.0.0"
+		"wait-for-localhost": "^4.1.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,13 @@ $ wait-for-localhost --help
     $ wait-for-localhost [port]
 
   Options
-    --use-get  Use the HTTP-method GET instead of HEAD to test if the server is ready
-    --path     Use a custom path. For example, /health for a health-check endpoint.
+    --use-get    Use the HTTP-method GET instead of HEAD to test if the server is ready
+    --path       Use a custom path. For example, /health for a health-check endpoint.
+    --statusCode Define status codes indicating the server is ready. 
 
   Example
     $ wait-for-localhost 8080 && echo 'Server is ready'
+    $ wait-for-localhost 8080 --statusCode 200 --statusCode 201 && echo 'Server is ready'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -21,13 +21,13 @@ $ wait-for-localhost --help
     $ wait-for-localhost [port]
 
   Options
-    --use-get    Use the HTTP-method GET instead of HEAD to test if the server is ready
-    --path       Use a custom path. For example, /health for a health-check endpoint.
-    --statusCode Define status codes indicating the server is ready. 
+    --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready
+    --path          Use a custom path. For example, /health for a health-check endpoint.
+    --status-codes  Define status codes indicating the server is ready. 
 
   Example
     $ wait-for-localhost 8080 && echo 'Server is ready'
-    $ wait-for-localhost 8080 --statusCode 200 --statusCode 201 && echo 'Server is ready'
+    $ wait-for-localhost 8080 --status-codes 200 --status-codes 201 && echo 'Server is ready'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,9 @@ $ wait-for-localhost --help
     --path          Use a custom path. For example, /health for a health-check endpoint.
     --status-codes  Define status codes indicating the server is ready. 
 
-  Example
+  Examples
     $ wait-for-localhost 8080 && echo 'Server is ready'
-    $ wait-for-localhost 8080 --status-codes 200 --status-codes 201 && echo 'Server is ready'
+    $ wait-for-localhost 8080 --status-codes 200,201 && echo 'Server is ready'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -21,9 +21,9 @@ $ wait-for-localhost --help
     $ wait-for-localhost [port]
 
   Options
-    --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready
+    --use-get       Use the HTTP-method GET instead of HEAD to test if the server is ready.
     --path          Use a custom path. For example, /health for a health-check endpoint.
-    --status-codes  Define status codes indicating the server is ready. 
+    --status-codes  Define status codes indicating the server is ready. [Default: 200]
 
   Examples
     $ wait-for-localhost 8080 && echo 'Server is ready'

--- a/test.js
+++ b/test.js
@@ -54,7 +54,7 @@ test('use path option', async t => {
 	await server.close();
 });
 
-test('use custom statusCode', async t => {
+test('use statusCodes option', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
@@ -64,24 +64,24 @@ test('use custom statusCode', async t => {
 		t.pass();
 	});
 
-	await execa('./cli.js', [server.port, '--statusCode', '201']);
+	await execa('./cli.js', [server.port, '--status-codes', '201']);
 
 	t.pass();
 
 	await server.close();
 });
 
-test('use custom statusCode list', async t => {
+test('use multiple statusCodes options', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get('/health', async (request, response) => {
+	server.get('/', async (request, response) => {
 		await delay(1000);
 		response.status(202).end();
 		t.pass();
 	});
 
-	await execa('./cli.js', [server.port, '--statusCode', '201', '--statusCode', '202']);
+	await execa('./cli.js', [server.port, '--status-codes', '201', '--status-codes', '202']);
 
 	t.pass();
 

--- a/test.js
+++ b/test.js
@@ -53,3 +53,37 @@ test('use path option', async t => {
 
 	await server.close();
 });
+
+test('use custom statusCode', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		await delay(1000);
+		response.status(201).end();
+		t.pass();
+	});
+
+	await execa('./cli.js', [server.port, '--statusCode', '201']);
+
+	t.pass();
+
+	await server.close();
+});
+
+test('use custom statusCode list', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/health', async (request, response) => {
+		await delay(1000);
+		response.status(202).end();
+		t.pass();
+	});
+
+	await execa('./cli.js', [server.port, '--statusCode', '201', '--statusCode', '202']);
+
+	t.pass();
+
+	await server.close();
+});

--- a/test.js
+++ b/test.js
@@ -81,7 +81,7 @@ test('use multiple statusCodes options', async t => {
 		t.pass();
 	});
 
-	await execa('./cli.js', [server.port, '--status-codes', '201', '--status-codes', '202']);
+	await execa('./cli.js', [server.port, '--status-codes', '201,202']);
 
 	t.pass();
 


### PR DESCRIPTION
Allow the user to specify the HTTP status codes considered as succesful response.

Currently the server has to respond with 200 to pass the check. With this change the user can specify one or multiple HTTP status codes to pass the check.

Requires https://github.com/sindresorhus/wait-for-localhost/pull/18 to be merged and released.